### PR TITLE
Introduce MessageApiReactor and factory for V4 MESSAGE APIs, add RFC and tests

### DIFF
--- a/docs/rfc-kafka-consumer-plugin.md
+++ b/docs/rfc-kafka-consumer-plugin.md
@@ -1,0 +1,187 @@
+# RFC: Kafka Consumer Plugin for APIM Gateway (V4 Message APIs)
+
+## 1. Summary
+
+Реализовать полноценный Kafka consumer execution path в APIM Gateway для V4 `MESSAGE` API: Gateway читает сообщения из Kafka, запускает flow/policy chain на каждое сообщение, фиксирует измеримый результат (лог/метрика/trace), и управляет delivery semantics (ack/retry/DLQ).
+
+Текущее состояние в ветке:
+- есть routing в отдельный `MessageApiReactorFactory` для `ApiType.MESSAGE` + listeners `SUBSCRIPTION/KAFKA`;
+- reactor wiring добавлен в Spring;
+- `MessageApiReactor` пока только thin-wrapper над `TcpApiReactor`;
+- pipeline TCP имеет TODO на message/subscription-specific chain.
+
+---
+
+## 2. Goals
+
+1. Gateway в роли Kafka consumer обрабатывает сообщения через flow/policy.
+2. Policy execution даёт наблюдаемый side-effect.
+3. Поддерживается надёжная стратегия commit/retry/DLQ.
+4. Имеется real e2e тест с реальным Kafka broker.
+
+## 3. Non-Goals
+
+- Exactly-once semantics в первой итерации.
+- Полный parity со всеми enterprise kafka policies в MVP.
+- Переработка HTTP/TCP pipeline вне message path.
+
+---
+
+## 4. Target Architecture
+
+### 4.1 Components
+- `MessageApiReactor` (отдельный execution pipeline, не просто wrapper).
+- `MessageApiProcessorChainFactory` (before/after/security/error chains).
+- Kafka Entrypoint Connector (consumer-side ingest).
+- Kafka Endpoint Connector (publish/DLQ path).
+- Message Execution Context (topic/partition/offset/key/headers).
+- Observability hooks (metrics/logging/tracing).
+
+### 4.2 Phase Mapping (предлагаемая)
+- `CONSUME_INIT` — получение рекорда и обогащение context.
+- `MESSAGE_REQUEST` — policy pre-processing.
+- `MESSAGE_RESPONSE` — post-processing + decision commit/retry.
+- `ERROR` — error processors + DLQ decision.
+
+---
+
+## 5. Delivery Semantics (MVP)
+
+- **Baseline**: at-least-once.
+- Commit offset только после успешного выполнения flow/policies.
+- Ошибки:
+  - retriable: retry с backoff и лимитом попыток;
+  - non-retriable: DLQ publish + mark failed.
+
+---
+
+## 6. Observability Contract
+
+Обязательные метрики:
+- `kafka_consume_total`
+- `kafka_process_success_total`
+- `kafka_process_error_total`
+- `kafka_retry_total`
+- `kafka_dlq_total`
+- `kafka_process_latency_ms`
+
+Структурированные логи:
+- `apiId`, `planId`, `topic`, `partition`, `offset`, `policyId`, `outcome`, `attempt`.
+
+Tracing:
+- span `kafka.consume`
+- child span `message.flow`
+- child spans per policy execution
+
+---
+
+## 7. Security & Isolation
+
+- Поддержка Kafka auth (SASL/SSL) через конфиг connectors.
+- Tenant isolation через existing endpoint manager constraints.
+- Плановые ограничения (`plan`, `subscription`) в message chain.
+
+---
+
+## 8. Implementation Plan (Phased)
+
+### Phase A — Core Execution Context
+- Ввести `MessageExecutionContext`/internal attributes.
+- Добавить mapping KafkaRecord -> context.
+
+**DoD**: unit tests на все ключевые поля.
+
+### Phase B — Message Processor Chain
+- Реализовать `MessageApiProcessorChainFactory`.
+- Подключить в `MessageApiReactor`.
+
+**DoD**: порядок chain вызовов тестами подтверждён.
+
+### Phase C — Policy/Flow Integration
+- Подключить phase mapping `MESSAGE_REQUEST/RESPONSE`.
+- Гарантировать policy execution per message.
+
+**DoD**: integration test показывает side-effect policy.
+
+### Phase D — Commit/Retry/DLQ
+- Реализовать retry policy + DLQ publish.
+- Commit только после success path.
+
+**DoD**: integration tests success/retry/dlq.
+
+### Phase E — E2E
+- Реальный Kafka broker (без эмуляции).
+- Gateway consumer path end-to-end.
+
+**DoD**: тест воспроизводимо green.
+
+---
+
+## 9. E2E Acceptance Scenario (канонический)
+
+1. Поднять Kafka.
+2. Деплоить MESSAGE API с Kafka listener + policy.
+3. Отправить message в topic.
+4. Убедиться, что Gateway:
+   - прочитал message,
+   - выполнил policy,
+   - записал metric/log/trace,
+   - корректно обработал offset.
+
+---
+
+## 10. Risks & Mitigations
+
+- **Risk**: commit до завершения policy -> потеря semantics.
+  **Mitigation**: commit only after post-flow success.
+
+- **Risk**: rebalance при in-flight message.
+  **Mitigation**: pause/drain protocol + graceful shutdown hooks.
+
+- **Risk**: policy latency повышает lag.
+  **Mitigation**: bounded concurrency + lag monitoring.
+
+---
+
+## 11. Rollout Strategy
+
+- Feature flag: `gateway.message.kafka.consumer.enabled`.
+- Canary rollout по environment/tag.
+- Быстрый rollback: выключение флага и возврат к текущему behavior.
+
+---
+
+## 12. Open Questions
+
+1. Нужен ли early support for transactional consumer (EOS)?
+2. Какая default retry policy (count/backoff/jitter)?
+3. Где хранить failure metadata для DLQ replay?
+4. Требуется ли per-plan QoS policy для Kafka consumption?
+
+---
+
+## 13. Success Criteria
+
+- 99%+ успешных обработок в номинальном потоке.
+- Отсутствие silent loss при graceful shutdown.
+- Наблюдаемость покрывает root-cause за < 5 мин.
+
+---
+
+## 14. Sprint Backlog (предлагаемый)
+
+### Sprint 1
+- MessageExecutionContext contract + tests.
+- MessageApiProcessorChainFactory skeleton.
+- MessageApiReactor: separate chain (не только wrapper).
+- Happy path flow/policy invocation test.
+
+### Sprint 2
+- Kafka commit/retry baseline.
+- Structured logging + base metrics.
+- Real Kafka e2e (single broker, one topic, one policy side effect).
+
+### Sprint 3
+- DLQ + rebalance hardening.
+- Perf and soak tests.
+- Rollout flags + docs.

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/spring/ApiHandlerConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/spring/ApiHandlerConfiguration.java
@@ -48,6 +48,7 @@ import io.gravitee.gateway.reactive.flow.condition.evaluation.HttpMethodConditio
 import io.gravitee.gateway.reactive.flow.condition.evaluation.PathBasedConditionFilter;
 import io.gravitee.gateway.reactive.handlers.api.processor.ApiProcessorChainFactory;
 import io.gravitee.gateway.reactive.handlers.api.v4.DefaultApiReactorFactory;
+import io.gravitee.gateway.reactive.handlers.api.v4.MessageApiReactorFactory;
 import io.gravitee.gateway.reactive.handlers.api.v4.TcpApiReactorFactory;
 import io.gravitee.gateway.reactive.platform.organization.policy.OrganizationPolicyChainFactoryManager;
 import io.gravitee.gateway.reactive.policy.HttpPolicyFactory;
@@ -309,6 +310,29 @@ public class ApiHandlerConfiguration {
         GatewayConfiguration gatewayConfiguration
     ) {
         return new TcpApiReactorFactory(
+            configuration,
+            node,
+            entrypointConnectorPluginManager,
+            endpointConnectorPluginManager,
+            requestTimeoutConfiguration,
+            openTelemetryConfiguration,
+            openTelemetryFactory,
+            instrumenterTracerFactories,
+            gatewayConfiguration
+        );
+    }
+
+    @Bean
+    ReactorFactory<io.gravitee.gateway.reactive.handlers.api.v4.Api> messageApiReactorFactory(
+        EntrypointConnectorPluginManager entrypointConnectorPluginManager,
+        EndpointConnectorPluginManager endpointConnectorPluginManager,
+        RequestTimeoutConfiguration requestTimeoutConfiguration,
+        OpenTelemetryConfiguration openTelemetryConfiguration,
+        OpenTelemetryFactory openTelemetryFactory,
+        @Autowired(required = false) List<InstrumenterTracerFactory> instrumenterTracerFactories,
+        GatewayConfiguration gatewayConfiguration
+    ) {
+        return new MessageApiReactorFactory(
             configuration,
             node,
             entrypointConnectorPluginManager,

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/MessageApiReactor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/MessageApiReactor.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactive.handlers.api.v4;
+
+import io.gravitee.gateway.env.RequestTimeoutConfiguration;
+import io.gravitee.gateway.opentelemetry.TracingContext;
+import io.gravitee.gateway.reactive.api.context.DeploymentContext;
+import io.gravitee.gateway.reactive.core.v4.endpoint.EndpointManager;
+import io.gravitee.node.api.Node;
+import io.gravitee.node.api.configuration.Configuration;
+import io.gravitee.plugin.entrypoint.EntrypointConnectorPluginManager;
+
+/**
+ * Dedicated reactor for message APIs.
+ *
+ * <p>
+ * This implementation currently reuses the TCP reactive handling pipeline and opens a dedicated extension point for
+ * message-specific flow/security processing in follow-up iterations.
+ */
+public class MessageApiReactor extends TcpApiReactor {
+
+    public MessageApiReactor(
+        final Api api,
+        final Node node,
+        final Configuration configuration,
+        final DeploymentContext deploymentContext,
+        final EntrypointConnectorPluginManager entrypointConnectorPluginManager,
+        final EndpointManager endpointManager,
+        final RequestTimeoutConfiguration requestTimeoutConfiguration,
+        final TracingContext tracingContext
+    ) {
+        super(
+            api,
+            node,
+            configuration,
+            deploymentContext,
+            entrypointConnectorPluginManager,
+            endpointManager,
+            requestTimeoutConfiguration,
+            tracingContext
+        );
+    }
+
+    @Override
+    public String toString() {
+        return "MessageApiReactor API id[" + api.getId() + "] name[" + api.getName() + "] version[" + api.getApiVersion() + ']';
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/MessageApiReactorFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/MessageApiReactorFactory.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactive.handlers.api.v4;
+
+import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.definition.model.v4.ApiType;
+import io.gravitee.definition.model.v4.listener.ListenerType;
+import io.gravitee.gateway.env.GatewayConfiguration;
+import io.gravitee.gateway.env.RequestTimeoutConfiguration;
+import io.gravitee.gateway.opentelemetry.TracingContext;
+import io.gravitee.gateway.reactive.core.context.DefaultDeploymentContext;
+import io.gravitee.gateway.reactive.core.v4.analytics.AnalyticsUtils;
+import io.gravitee.gateway.reactive.core.v4.endpoint.DefaultEndpointManager;
+import io.gravitee.gateway.reactive.reactor.v4.reactor.ReactorFactory;
+import io.gravitee.gateway.reactor.Reactable;
+import io.gravitee.gateway.reactor.handler.ReactorHandler;
+import io.gravitee.node.api.Node;
+import io.gravitee.node.api.configuration.Configuration;
+import io.gravitee.node.api.opentelemetry.InstrumenterTracerFactory;
+import io.gravitee.node.api.opentelemetry.Tracer;
+import io.gravitee.node.opentelemetry.OpenTelemetryFactory;
+import io.gravitee.node.opentelemetry.configuration.OpenTelemetryConfiguration;
+import io.gravitee.plugin.endpoint.EndpointConnectorPluginManager;
+import io.gravitee.plugin.entrypoint.EntrypointConnectorPluginManager;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class MessageApiReactorFactory implements ReactorFactory<Api> {
+
+    private final Configuration configuration;
+    private final Node node;
+    private final EntrypointConnectorPluginManager entrypointConnectorPluginManager;
+    private final EndpointConnectorPluginManager endpointConnectorPluginManager;
+    private final RequestTimeoutConfiguration requestTimeoutConfiguration;
+    private final OpenTelemetryConfiguration openTelemetryConfiguration;
+    private final OpenTelemetryFactory openTelemetryFactory;
+    private final List<InstrumenterTracerFactory> instrumenterTracerFactories;
+    private final GatewayConfiguration gatewayConfiguration;
+
+    @Override
+    public boolean support(final Class<? extends Reactable> clazz) {
+        return Api.class.isAssignableFrom(clazz);
+    }
+
+    @Override
+    public boolean canCreate(final Api api) {
+        return (
+            api.getDefinitionVersion() == DefinitionVersion.V4 &&
+            api.getDefinition().getType() == ApiType.MESSAGE &&
+            api
+                .getDefinition()
+                .getListeners()
+                .stream()
+                .anyMatch(listener -> listener.getType() == ListenerType.SUBSCRIPTION || listener.getType() == ListenerType.KAFKA)
+        );
+    }
+
+    @Override
+    public ReactorHandler create(final Api api) {
+        DefaultDeploymentContext deploymentContext = new DefaultDeploymentContext();
+        final DefaultEndpointManager endpointManager = new DefaultEndpointManager(
+            api.getDefinition(),
+            endpointConnectorPluginManager,
+            deploymentContext,
+            gatewayConfiguration
+        );
+
+        return new MessageApiReactor(
+            api,
+            node,
+            configuration,
+            deploymentContext,
+            entrypointConnectorPluginManager,
+            endpointManager,
+            requestTimeoutConfiguration,
+            createTracingContext(api)
+        );
+    }
+
+    protected TracingContext createTracingContext(final Api api) {
+        if (isApiTracingEnabled(api)) {
+            Tracer tracer = openTelemetryFactory.createTracer(
+                api.getId(),
+                api.getName(),
+                "API_V4_MESSAGE",
+                api.getApiVersion(),
+                instrumenterTracerFactories
+            );
+            return new TracingContext(tracer, isApiTracingEnabled(api), isApiTracingVerboseEnabled(api));
+        }
+        return TracingContext.noop();
+    }
+
+    protected boolean isApiTracingEnabled(final Api api) {
+        return AnalyticsUtils.isTracingEnabled(
+            openTelemetryConfiguration,
+            api.getDefinition() != null ? api.getDefinition().getAnalytics() : null
+        );
+    }
+
+    protected boolean isApiTracingVerboseEnabled(final Api api) {
+        return AnalyticsUtils.isTracingVerbose(
+            openTelemetryConfiguration,
+            api.getDefinition() != null ? api.getDefinition().getAnalytics() : null
+        );
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/MessageApiReactorFactoryTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/MessageApiReactorFactoryTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactive.handlers.api.v4;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.definition.model.v4.ApiType;
+import io.gravitee.definition.model.v4.listener.Listener;
+import io.gravitee.definition.model.v4.listener.ListenerType;
+import io.gravitee.definition.model.v4.listener.entrypoint.Entrypoint;
+import io.gravitee.definition.model.v4.listener.http.HttpListener;
+import io.gravitee.definition.model.v4.listener.subscription.SubscriptionListener;
+import io.gravitee.gateway.env.GatewayConfiguration;
+import io.gravitee.gateway.env.RequestTimeoutConfiguration;
+import io.gravitee.node.api.Node;
+import io.gravitee.node.api.configuration.Configuration;
+import io.gravitee.node.opentelemetry.OpenTelemetryFactory;
+import io.gravitee.node.opentelemetry.configuration.OpenTelemetryConfiguration;
+import io.gravitee.plugin.endpoint.EndpointConnectorPluginManager;
+import io.gravitee.plugin.entrypoint.EntrypointConnectorPluginManager;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@ExtendWith(MockitoExtension.class)
+class MessageApiReactorFactoryTest {
+
+    MessageApiReactorFactory cut;
+
+    @Mock
+    Configuration configuration;
+
+    @Mock
+    Node node;
+
+    @Mock
+    EntrypointConnectorPluginManager entrypoints;
+
+    @Mock
+    EndpointConnectorPluginManager endpoints;
+
+    @Mock
+    RequestTimeoutConfiguration timeoutConfig;
+
+    @Mock
+    OpenTelemetryConfiguration openTelemetryConfiguration;
+
+    @Mock
+    OpenTelemetryFactory openTelemetryFactory;
+
+    @Mock
+    GatewayConfiguration gatewayConfiguration;
+
+    @BeforeEach
+    void before() {
+        cut = new MessageApiReactorFactory(
+            configuration,
+            node,
+            entrypoints,
+            endpoints,
+            timeoutConfig,
+            openTelemetryConfiguration,
+            openTelemetryFactory,
+            List.of(),
+            gatewayConfiguration
+        );
+    }
+
+    static Stream<Arguments> apis() {
+        io.gravitee.definition.model.v4.Api api1 = new io.gravitee.definition.model.v4.Api();
+        api1.setDefinitionVersion(DefinitionVersion.V4);
+        api1.setListeners(List.of(new SubscriptionListener()));
+        api1.setType(ApiType.MESSAGE);
+        io.gravitee.definition.model.v4.Api kafkaTypedApi = new io.gravitee.definition.model.v4.Api();
+        kafkaTypedApi.setDefinitionVersion(DefinitionVersion.V4);
+        final Listener kafkaTypedListener = mock(Listener.class);
+        when(kafkaTypedListener.getType()).thenReturn(ListenerType.KAFKA);
+        kafkaTypedApi.setListeners(List.of(kafkaTypedListener));
+        kafkaTypedApi.setType(ApiType.MESSAGE);
+
+        io.gravitee.definition.model.v4.Api api2 = new io.gravitee.definition.model.v4.Api();
+        api2.setDefinitionVersion(DefinitionVersion.V2);
+        api2.setListeners(List.of(new SubscriptionListener()));
+        api2.setType(ApiType.MESSAGE);
+
+        io.gravitee.definition.model.v4.Api api3 = new io.gravitee.definition.model.v4.Api();
+        api3.setDefinitionVersion(DefinitionVersion.V4);
+        api3.setListeners(List.of(new SubscriptionListener()));
+        api3.setType(ApiType.PROXY);
+
+        io.gravitee.definition.model.v4.Api api4 = new io.gravitee.definition.model.v4.Api();
+        api4.setDefinitionVersion(DefinitionVersion.V4);
+        api4.setListeners(List.of(new HttpListener()));
+        api4.setType(ApiType.MESSAGE);
+
+        return Stream.of(
+            arguments(new Api(api1), true),
+            arguments(new Api(kafkaTypedApi), true),
+            arguments(new Api(api2), false),
+            arguments(new Api(api3), false),
+            arguments(new Api(api4), false)
+        );
+    }
+
+    @MethodSource("apis")
+    @ParameterizedTest
+    void should_call_can_create(Api api, boolean canCreate) {
+        assertThat(cut.canCreate(api)).isEqualTo(canCreate);
+    }
+
+    @Test
+    void should_create() {
+        io.gravitee.definition.model.v4.Api apiDef = new io.gravitee.definition.model.v4.Api();
+        apiDef.setDefinitionVersion(DefinitionVersion.V4);
+        SubscriptionListener listener = new SubscriptionListener();
+        listener.setEntrypoints(List.of(new Entrypoint()));
+        apiDef.setListeners(List.of(listener));
+        apiDef.setType(ApiType.MESSAGE);
+
+        // avoid reactor to complain on stop timeout read
+        when(configuration.getProperty(any(), eq(Long.class), any())).thenReturn(0L);
+
+        assertThat(cut.create(new Api(apiDef))).isInstanceOf(MessageApiReactor.class);
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide a dedicated reactor execution path for V4 `MESSAGE` APIs (Kafka/subscription listeners) to enable message consumption and future message-specific flow/policy processing.
- Expose a Spring bean so the Gateway can wire a message reactor separately from the TCP reactor and enable feature rollout and tracing for message APIs.

### Description

- Add RFC `docs/rfc-kafka-consumer-plugin.md` describing goals, architecture, delivery semantics, observability and phased implementation for a Kafka consumer plugin. 
- Introduce `MessageApiReactor` as a message-specific reactor that currently reuses `TcpApiReactor` behavior and provides a distinct `toString()` and extension point for future message-specific processing. 
- Add `MessageApiReactorFactory` which selects V4 `ApiType.MESSAGE` APIs with `SUBSCRIPTION` or `KAFKA` listeners and creates `MessageApiReactor` instances with tracing and endpoint manager wiring. 
- Register the new factory as a Spring bean by adding `messageApiReactorFactory` to `ApiHandlerConfiguration`. 
- Add unit tests in `MessageApiReactorFactoryTest` to validate `canCreate` logic and reactor creation behaviour.

### Testing

- Added `MessageApiReactorFactoryTest` unit tests and executed unit tests; `MessageApiReactorFactoryTest` passed. 
- Ran the module's automated unit test suite and no regressions were observed in the changed module.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a6f99fb3d8832c8253a01b28b454b2)